### PR TITLE
Remove CLI description parameter from GenFormula

### DIFF
--- a/src/CompileScript.php
+++ b/src/CompileScript.php
@@ -34,7 +34,6 @@ final class CompileScript
     public function compile(Meta $meta): array
     {
         $sources = [];
-        $cliDesc = '';
         $generator = $meta->getGenerator();
 
         foreach ($generator as $resource) {
@@ -45,9 +44,6 @@ final class CompileScript
                 if (! $cliAttr) {
                     continue;
                 }
-
-                // Get CLI description for formula
-                $cliDesc = $cliAttr->description;
 
                 $sources[] = ($this->genScript)(
                     uri: $resource->uriPath,
@@ -60,7 +56,7 @@ final class CompileScript
         // Generate formula if it's a git repository
         $formula = null;
         if (is_dir($meta->appDir . '/.git')) {
-            $formula = ($this->genFormula)($meta, $cliDesc);
+            $formula = ($this->genFormula)($meta);
         }
 
         $this->dumpSources($sources, $meta->appDir . '/bin/cli');

--- a/src/GenFormula.php
+++ b/src/GenFormula.php
@@ -28,7 +28,7 @@ final class GenFormula
 # frozen_string_literal: true
 
 class %s < Formula
-  desc "%s"
+  desc "Command line interface for %s application"
   homepage "%s"
   head "%s", branch: "%s"
   license "MIT"
@@ -100,7 +100,7 @@ EOT;
     }
 
     /** @return Formula */
-    public function __invoke(Meta $meta, string $description): array
+    public function __invoke(Meta $meta): array
     {
         $repoUrl = $this->gitCommand->getRemoteUrl();
 
@@ -115,7 +115,7 @@ EOT;
         $content = sprintf(
             self::TEMPLATE,
             ucfirst($formulaName),
-            $description,
+            $meta->name,
             "https://github.com/{$repoInfo['org']}/{$repoInfo['repo']}",
             $repoUrl,
             $branch,

--- a/tests/GenFormulaTest.php
+++ b/tests/GenFormulaTest.php
@@ -55,7 +55,7 @@ final class GenFormulaTest extends TestCase
             }
         };
         $genFormula = new GenFormula($gitCommand);
-        $result = $genFormula($this->meta, 'Test CLI command');
+        $result = $genFormula($this->meta);
 
         // Check formula path
         $expectedPath = sprintf(
@@ -68,7 +68,7 @@ final class GenFormulaTest extends TestCase
         // Check formula content
         $content = $result['content'];
         $this->assertStringContainsString('class Fakeproject < Formula', $content);
-        $this->assertStringContainsString('desc "Test CLI command"', $content);
+        $this->assertStringContainsString('desc "Command line interface for FakeVendor\FakeProject application"', $content);
         $this->assertStringContainsString('homepage "https://github.com/fakevendor/fake-project"', $content);
         $this->assertStringContainsString('head "https://github.com/fakevendor/fake-project.git"', $content);
         $this->assertStringContainsString('depends_on "php@', $content);
@@ -95,7 +95,7 @@ final class GenFormulaTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid GitHub URL format');
 
-        $genFormula($this->meta, 'Test CLI command');
+        $genFormula($this->meta);
     }
 
     /**
@@ -124,7 +124,7 @@ final class GenFormulaTest extends TestCase
         };
         $genFormula = new GenFormula($gitCommand);
 
-        $result = $genFormula($this->meta, 'Test CLI command');
+        $result = $genFormula($this->meta);
 
         $this->assertStringContainsString(
             sprintf('class %s < Formula', ucfirst($expectedFormulaName)),
@@ -160,7 +160,7 @@ final class GenFormulaTest extends TestCase
         };
         $genFormula = new GenFormula($gitCommand);
 
-        $result = $genFormula($this->meta, 'Test CLI command');
+        $result = $genFormula($this->meta);
 
         $this->assertStringContainsString(
             'homepage "https://github.com/fakevendor/fake-project"',


### PR DESCRIPTION
Refactor GenFormula invocation by eliminating the redundant CLI description parameter. The description now defaults to the meta name, simplifying both the function signature and its usage. Updated corresponding test cases and script logic to reflect this change.