### PR TITLE
Fail fast when a #[Cli] parameter is missing #[Option]

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -8,6 +8,7 @@ use BEAR\Cli\Attribute\Cli;
 use BEAR\Cli\Attribute\Option;
 use ReflectionMethod;
 
+use function sprintf;
 use function strtolower;
 use function substr;
 
@@ -32,7 +33,10 @@ final readonly class Config
     /** @var array<string> */
     public readonly array $longOptions;
 
-    /** @throws Exception\LogicException */
+    /**
+     * @throws Exception\LogicException When the method is not annotated with #[Cli].
+     * @throws Exception\MissingOptionAttributeException When a parameter is missing #[Option].
+     */
     public function __construct(
         public readonly string $uri,
         ReflectionMethod $method,
@@ -62,14 +66,28 @@ final readonly class Config
         return $attrs[0]->newInstance();
     }
 
-    /** @return array<string, CliOption> */
+    /**
+     * @return array<string, CliOption>
+     *
+     * @throws Exception\MissingOptionAttributeException When a parameter on a #[Cli]
+     *     method lacks the #[Option] attribute. Every parameter on a CLI-bound method
+     *     must declare #[Option] so the generator can map it to a long/short flag;
+     *     silently skipping would produce a command that can never receive the value.
+     */
     private function getOptions(ReflectionMethod $method): array
     {
         $options = [];
         foreach ($method->getParameters() as $param) {
             $attrs = $param->getAttributes(Option::class);
             if (! $attrs) {
-                continue; // @codeCoverageIgnore
+                throw new Exception\MissingOptionAttributeException(sprintf(
+                    'Parameter $%s of %s::%s() has no #[Option] attribute. ' .
+                    'When a method is annotated with #[Cli], every parameter must be ' .
+                    'annotated with #[Option(shortName: ..., description: ...)].',
+                    $param->getName(),
+                    $method->getDeclaringClass()->getName(),
+                    $method->getName(),
+                ));
             }
 
             $attr = $attrs[0]->newInstance();

--- a/src/Exception/MissingOptionAttributeException.php
+++ b/src/Exception/MissingOptionAttributeException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Cli\Exception;
+
+use LogicException;
+
+final class MissingOptionAttributeException extends LogicException
+{
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -81,4 +81,13 @@ class ConfigTest extends TestCase
         $config = new Config('app://self/greeting', $method);
         $this->assertSame('post', $config->method);
     }
+
+    public function testMissingOptionAttribute(): void
+    {
+        $this->expectException(Exception\MissingOptionAttributeException::class);
+        $this->expectExceptionMessage('Parameter $name of BEAR\Cli\Fake\FakeResource::onPut() has no #[Option] attribute.');
+
+        $method = new ReflectionMethod(FakeResource::class, 'onPut');
+        new Config('app://self/greeting', $method);
+    }
 }

--- a/tests/Fake/FakeExceptionResource.php
+++ b/tests/Fake/FakeExceptionResource.php
@@ -6,6 +6,7 @@ namespace BEAR\Cli;
 
 use BEAR\Cli\Fake\FakeErrorResource;
 use BEAR\Cli\Fake\FakeResource;
+use BEAR\Resource\Method;
 use BEAR\Resource\RequestInterface;
 use BEAR\Resource\ResourceInterface;
 use BEAR\Resource\ResourceObject;
@@ -63,8 +64,16 @@ class FakeExceptionResource implements ResourceInterface
     {
     }
 
-    public function href(string $rel, array $query = []): ResourceObject
+    public function href(string $rel, array $query = [], ResourceObject|null $ro = null): ResourceObject
     {
         return new FakeNonStringOutputResource();
+    }
+
+    public function newRequest(Method $method, string $uri, array $query = []): RequestInterface // @phpstan-ignore-line
+    {
+    }
+
+    public function crawl(string $uri, string $linkKey, array $query = []): ResourceObject // @phpstan-ignore-line
+    {
     }
 }

--- a/tests/Fake/FakeResource.php
+++ b/tests/Fake/FakeResource.php
@@ -47,4 +47,16 @@ class FakeResource extends ResourceObject
     public function noCliMethod(): void
     {
     }
+
+    /**
+     * Simulates an authoring mistake: a #[Cli] method whose parameter is missing #[Option].
+     * Used by ConfigTest::testMissingOptionAttribute to verify fail-fast behaviour.
+     */
+    #[Cli(
+        name: 'missing-option',
+        description: 'Resource with a parameter that has no #[Option] attribute',
+    )]
+    public function onPut(string $name): void
+    {
+    }
 }

--- a/tests/Fake/FakeResourceFactory.php
+++ b/tests/Fake/FakeResourceFactory.php
@@ -72,7 +72,7 @@ class FakeResourceFactory implements ResourceInterface
     {
     }
 
-    public function href(string $rel, array $query = []): ResourceObject
+    public function href(string $rel, array $query = [], ResourceObject|null $ro = null): ResourceObject
     {
     }
 }

--- a/tests/Fake/FakeResourceFactory.php
+++ b/tests/Fake/FakeResourceFactory.php
@@ -4,6 +4,7 @@
 
 namespace BEAR\Cli\Fake;
 
+use BEAR\Resource\Method;
 use BEAR\Resource\RequestInterface;
 use BEAR\Resource\ResourceInterface;
 use BEAR\Resource\ResourceObject;
@@ -73,6 +74,14 @@ class FakeResourceFactory implements ResourceInterface
     }
 
     public function href(string $rel, array $query = [], ResourceObject|null $ro = null): ResourceObject
+    {
+    }
+
+    public function newRequest(Method $method, string $uri, array $query = []): RequestInterface
+    {
+    }
+
+    public function crawl(string $uri, string $linkKey, array $query = []): ResourceObject
     {
     }
 }

--- a/tests/Fake/FakeStub2Resource.php
+++ b/tests/Fake/FakeStub2Resource.php
@@ -2,6 +2,7 @@
 
 namespace BEAR\Cli;
 
+use BEAR\Resource\Method;
 use BEAR\Resource\RequestInterface;
 use BEAR\Resource\ResourceInterface;
 use BEAR\Resource\ResourceObject;
@@ -58,8 +59,16 @@ final class FakeStub2Resource implements ResourceInterface
     {
     }
 
-    public function href(string $rel, array $query = []): ResourceObject
+    public function href(string $rel, array $query = [], ResourceObject|null $ro = null): ResourceObject
     {
         return new FakeNonStringOutputResource();
+    }
+
+    public function newRequest(Method $method, string $uri, array $query = []): RequestInterface // @phpstan-ignore-line
+    {
+    }
+
+    public function crawl(string $uri, string $linkKey, array $query = []): ResourceObject // @phpstan-ignore-line
+    {
     }
 }

--- a/tests/Fake/FakeStubResource.php
+++ b/tests/Fake/FakeStubResource.php
@@ -2,6 +2,7 @@
 
 namespace BEAR\Cli;
 
+use BEAR\Resource\Method;
 use BEAR\Resource\RequestInterface;
 use BEAR\Resource\ResourceInterface;
 use BEAR\Resource\ResourceObject;
@@ -57,8 +58,16 @@ final class FakeStubResource implements ResourceInterface
     {
     }
 
-    public function href(string $rel, array $query = []): ResourceObject
+    public function href(string $rel, array $query = [], ResourceObject|null $ro = null): ResourceObject
     {
         return new FakeNonStringOutputResource();
+    }
+
+    public function newRequest(Method $method, string $uri, array $query = []): RequestInterface
+    {
+    }
+
+    public function crawl(string $uri, string $linkKey, array $query = []): ResourceObject
+    {
     }
 };


### PR DESCRIPTION
## Summary

When a resource method is annotated with `#[Cli]` but one of its parameters has no `#[Option]` attribute, `Config::getOptions` silently skipped the parameter and the generated script never produced a flag for it.

The resulting `bin/cli/*` then called the method with the parameter unbound:
- plain scalar parameters → confusing PHP `TypeError` at call time
- `#[Input]` DTO parameters → half-hydrated object (CLI has no `$_GET` / `$_POST`)

In every case the failure surfaced far away from the actual mistake (in the resource method definition) and gave no hint about the missing `#[Option]`.

This PR throws a dedicated `MissingOptionAttributeException` at `Config` construction so the misuse fails at compile / generation time with a message that names the offending parameter and method:

```text
Parameter $input of MyVendor\Cms\Resource\App\Article::onPost() has no #[Option] attribute.
When a method is annotated with #[Cli], every parameter must be annotated with #[Option(shortName: ..., description: ...)].
```

## Changes

- `src/Exception/MissingOptionAttributeException.php` — new `final` class extending `\LogicException`, matching the existing exception style in this package
- `src/Config.php` — replace silent `continue` (previously `@codeCoverageIgnore`) with `throw new MissingOptionAttributeException(...)`; update `@throws` docblocks on the constructor and `getOptions()`
- `tests/Fake/FakeResource.php` — add a method that reproduces the authoring mistake (`#[Cli]` set, parameter without `#[Option]`)
- `tests/ConfigTest.php` — add `testMissingOptionAttribute()` covering the new path

## BC considerations

This is a behaviour change but not a contract break: any method previously hitting the silent-skip branch was already broken at runtime. The new behaviour turns a latent runtime bug into an eager `LogicException` at script-generation time. No public API signature changes.

## Test plan

- [x] `./vendor/bin/phpunit` — 62/62 OK locally (61 existing + 1 new)
- [x] `./vendor/bin/phpcbf` / `./vendor/bin/phpcs` — clean
- [x] `./vendor/bin/phpstan analyse -c phpstan.neon` — no errors